### PR TITLE
Add ivoatex submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-ivoatex
 *.aux
 *.log
 *.out

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ivoatex"]
+	path = ivoatex
+	url = https://github.com/ivoa-std/ivoatex.git

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ Under development.
 
 # Working on this Document
 
-Since authoring a document on github is an experiment, this is a little bumpy... The ivoatex
-toolkit normally relies on some subversion import magic to make it look local. The easy Linux way to fake that is to create a symlink, e.g. 
+Remember to checkout the repository with its submodules.
 
-ivoatex -> ivoatex -> ../../volute.svn/ivoapub/ivoatex/
+    git clone --recurse-submodules https://github.com/ivoa-std/architecture.git
 
 Then: run "make" and hope you have all the necessary tools installed.
 


### PR DESCRIPTION
This includes ivoatex as a submodule. 

The PR was created with
```
$ git submodule add https://github.com/ivoa-std/ivoatex.git ivoatex
$ git commit -m "Add ivoatex submodule"
```

Checking out and cloning should be done with adding the  `--recurse-submodules` option.