### PR TITLE
Fix references in section 5.3 (VOTable)

### DIFF
--- a/Arch.tex
+++ b/Arch.tex
@@ -260,8 +260,8 @@ The VOTable format is an XML standard for the interchange of data represented as
 In this context, a table is an unordered set of rows, each of a uniform structure, as specified 
 in the table description (the table metadata). Each row in a table is a sequence of table cells, 
 and each of these contains either a primitive data type, or an array of such primitives. VOTable 
-is derived from the Astrores format [1], itself modeled on the FITS Table format [2]; VOTable 
-was designed to be close to the FITS Binary Table format. 
+is derived from the Astrores format \citep{astrores}, itself modeled on the FITS Table format 
+\citep{std:FITS}; VOTable was designed to be close to the FITS Binary Table format. 
 
 \subsection{SAMP}
 
@@ -853,6 +853,6 @@ use network attached data stores to persist and exchange data in a standard way.
 
 TODO: some forward-looking text here about the motivation, plans, and promise?
 
-\bibliography{ivoatex/ivoabib}
+\bibliography{ivoatex/ivoabib,localrefs}
 
 \end{document}

--- a/localrefs.bib
+++ b/localrefs.bib
@@ -1,0 +1,10 @@
+@Misc{astrores,
+   author = {Alberto Accomazzi and Miguel Albrecht and Allan Brighton and
+             Pierre Fernique and Damien Guillaume and Robert Hanisch and
+             Fran\c{c}ois Ochsenbein and Patricio Ortiz and
+             Marc Wenger and Andreas Wicenec},
+   title = {{Describing Astronomical Catalogues and Query Results with XML}},
+   year = {2001},
+   month = {jan},
+   url = {http://vizier.u-strasbg.fr/vizier/doc/astrores.htx}
+}


### PR DESCRIPTION
The references in section 5.3 were copied from the VOTable standard document text which has non-hyperlink numeric references to bibliography entries.  Those numbers don't refer to anything in the bib for this document, so I added `\citep` references and an entry in `localrefs.bib` for `Astrores`.