### PR TITLE
fix group name & update ivoatex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # ivoatex Makefile.  The ivoatex/README for the targets available.
 AUTHOR_EMAIL = marco.molinaro@inaf.it
-IVOA_GROUP = TCG
+IVOA_GROUP = Technical Coordination Group
 
 # short name of your document (edit $DOCNAME.tex; would be like RegTAP)
 DOCNAME = IVOAArchitecture


### PR DESCRIPTION
ivoatex sbmodule update to latest
TCG group name exploaded because ivoatex has that name in the mappings